### PR TITLE
Support for updating global tags from install script

### DIFF
--- a/collectors/etc/yaml_conf.py
+++ b/collectors/etc/yaml_conf.py
@@ -2,17 +2,71 @@
 
 import os
 import sys
+import re
 import yaml
 
+try:
+    import ruamel.yaml as rtyaml
+except ImportError:
+    rtyaml = None
 
-def load_collector_configuration(config_file):
+
+def get_yaml_conf_dir():
     current_script_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
     if "/collectors/0" in current_script_dir:
         yaml_conf_dir = os.path.join(current_script_dir[:current_script_dir.index("/collectors/0")], 'conf')
     else:
         yaml_conf_dir = os.path.join(current_script_dir, 'conf')
+    return yaml_conf_dir
+
+
+def load_collector_configuration(config_file):
+    yaml_conf_dir = get_yaml_conf_dir()
     with open(os.path.join(yaml_conf_dir, config_file), 'r') as stream:
         try:
-            return yaml.load(stream)
+            return yaml.safe_load(stream)
         except yaml.YAMLError as exc:
             print("Type error: {0}".format(exc))
+
+
+def to_dict(global_tags_string):
+    global_tags_string = re.sub(r'\s+', '', global_tags_string)
+    global_tags_string = global_tags_string.replace(';', ',')
+    global_tags_string = global_tags_string.replace(':', '=')
+    return dict(x.split('=') for x in global_tags_string.split(','))
+
+
+def set_global_tags(global_tags_string, overwrite=False, conf_path=None):
+    if conf_path is None:
+        conf_path = os.path.join(get_yaml_conf_dir(), "xcollector.yml")
+
+    with open(conf_path, 'r') as stream:
+        if rtyaml:
+            root = rtyaml.round_trip_load(stream)
+        else:
+            root = yaml.safe_load(stream)
+
+        if root['collector'] is None or 'config' not in root['collector']:
+            raise ConfigurationException(
+                "Can not find collector/config in the config file [%s]" % conf_path)
+        if "tags" in root['collector']['config'] and (not overwrite):
+            return False
+
+        try:
+            root['collector']['config']['tags'] = to_dict(global_tags_string)
+        except ValueError as error:
+            raise ConfigurationException(
+                "Invalid tag format [%s]. Expected format -> key1=value1, key2=value2."
+                % global_tags_string, error)
+
+    with open(conf_path, "w") as stream:
+        if rtyaml:
+            rtyaml.round_trip_dump(root, stream, default_flow_style=False)
+        else:
+            yaml.dump(root, stream, default_flow_style=False)
+
+    return True
+
+
+class ConfigurationException(Exception):
+    pass

--- a/tcollector.py
+++ b/tcollector.py
@@ -44,6 +44,9 @@ from Queue import Empty
 from Queue import Full
 from optparse import OptionParser, SUPPRESS_HELP
 
+from collectors.etc import yaml_conf
+
+
 # global variables.
 COLLECTORS = {}
 GENERATION = 0
@@ -961,6 +964,8 @@ def parse_cmdline(argv):
     parser.add_option('--compression-threshold', dest='compression_threshold',
                       type='int', default=defaults['compression_threshold'],
                       help=SUPPRESS_HELP)  # 'Minimum body size after which to enable compression
+    parser.add_option('--set-option-tags', dest='set_opt_global_tags',
+                      help=SUPPRESS_HELP)  # 'Username to use for HTTP Basic Auth when sending the data via HTTP'
     (options, args) = parser.parse_args(args=argv[1:])
     cmdline_dict = tag_str_list_to_dict(options.tags)
     for key, value in defaults['tags'].iteritems():
@@ -1041,6 +1046,13 @@ def main(argv):
     except:
         sys.stderr.write("Unexpected error: %s" % sys.exc_info()[0])
         return 1
+
+    if options.set_opt_global_tags:
+        updated = yaml_conf.set_global_tags(options.set_opt_global_tags, overwrite=True)
+        if updated:
+            return 0
+        else:
+            return 4
 
     if not check_file_permissions(options.logfile or DEFAULT_LOG) or not check_file_permissions(options.pidfile):
         return 2


### PR DESCRIPTION
Set the ENV variable XC_GLOBAL_TAGS to have the install script set/overwrite the tags config in xcollector.yml
Format for XC_GLOBAL_TAGS is KV_PAIR([;,]KV_PAIR)+ ie use comma or semi-colon to separate key value pairs
Format for KV_PAIR is KEY[=:]VALUE ie use equals or colon to separate key from value

Fixes #37 